### PR TITLE
Simplify tests for the tags

### DIFF
--- a/__tests__/[slug].test.tsx
+++ b/__tests__/[slug].test.tsx
@@ -3,15 +3,16 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import EpisodePage, {
+  getMetaDescription,
   getStaticPaths,
   getStaticProps,
+  getTitle,
   Params,
 } from '../pages/episodes/[slug]';
 import { getEpisodes } from '../utils/episodes-handlers';
 import { GetStaticPropsContext } from 'next';
-import { HeadWrapper } from '../utils/wrappers';
 import { altTexts } from '../utils/episode-descriptions';
 
 describe('EpisodePage', () => {
@@ -38,44 +39,16 @@ describe('EpisodePage', () => {
     expect(image).toBeInTheDocument();
   });
 
-  it('renders a title', async () => {
+  it('renders a title of first episode', () => {
     const episode = getEpisodes()[0];
-    const episodes = getEpisodes();
-
-    render(
-      <EpisodePage
-        episode={episode}
-        currentEpisodeNumber={1}
-        episodes={episodes}
-      />,
-      { wrapper: HeadWrapper }
-    );
-
-    await waitFor(() => {
-      expect(document.title).toEqual('Episode 1 - Peanutbutter girl comic');
-    });
+    const result = getTitle(episode.name);
+    expect(result).toEqual('Episode 1 - Peanutbutter girl comic');
   });
 
-  it('renders a meta description', async () => {
+  it('renders a meta description of first episode', async () => {
     const episode = getEpisodes()[0];
-    const episodes = getEpisodes();
-
-    render(
-      <EpisodePage
-        episode={episode}
-        currentEpisodeNumber={1}
-        episodes={episodes}
-      />,
-      { wrapper: HeadWrapper }
-    );
-
-    await waitFor(() => {
-      expect(
-        document
-          .querySelector('meta[name=description]')
-          ?.getAttribute('content')
-      ).toEqual('Episode 1');
-    });
+    const result = getMetaDescription(episode.name);
+    expect(result).toEqual('Episode 1');
   });
 
   describe('getStaticProps method', () => {

--- a/pages/episodes/[slug].tsx
+++ b/pages/episodes/[slug].tsx
@@ -13,6 +13,13 @@ export type EpisodePageProps = {
 export type Params = {
   slug: string;
 };
+export const getTitle = (name: string) => {
+  return `${name} - Peanutbutter girl comic`;
+};
+
+export const getMetaDescription = (name: string) => {
+  return name;
+};
 
 const EpisodePage: NextPage<EpisodePageProps> = props => {
   const {
@@ -23,8 +30,8 @@ const EpisodePage: NextPage<EpisodePageProps> = props => {
   return (
     <div className={'max-w-screen'}>
       <Head>
-        <title>{name} - Peanutbutter girl comic</title>
-        <meta name="description" content={name} />
+        <title>{getTitle(name)}</title>
+        <meta name="description" content={getMetaDescription(name)} />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Episode


### PR DESCRIPTION
The tests for `<title>` and `<meta>` were simplified in order to get rid of the warning `next-head-count` thrown by nextjs and thanks to that the simple function are tested. Those function returns title and tag meta description of given episode. As a result of that simplification the tests are separated from nextjs.